### PR TITLE
An option to just check if dependencies are sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## dev
+
+### Added
+
+- Added a `--check` option to verify if dependencies are already sorted.
+
 ## [0.1.1] - 2022-10-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ To sort dependencies without making changes to the depenencies list, the plugin 
 ```bash
 poetry sort
 ```
+
+The `--check` option can be used to verify if dependencies are sorted (e.g. for CI purposes).
+
+```bash
+if poetry sort --check; then
+    echo "It's all fine"
+else
+    echo "Please sort your dependencies"
+fi
+```

--- a/poetry_plugin_sort/plugins.py
+++ b/poetry_plugin_sort/plugins.py
@@ -5,6 +5,7 @@ from typing import Type
 from cleo.events import console_events
 from cleo.events.console_terminate_event import ConsoleTerminateEvent
 from cleo.events.event_dispatcher import EventDispatcher
+from cleo.helpers import option
 from cleo.io.io import IO
 from poetry.console.application import Application
 from poetry.console.commands.add import AddCommand
@@ -19,11 +20,15 @@ from poetry_plugin_sort.sort import Sorter
 class SortCommand(Command):
     name = "sort"
     description = "Sorts the dependencies in pyproject.toml"
+    options = [
+        option(
+            "check", flag=True, description="Don't sort, just check if already sorted."
+        )
+    ]
 
     def handle(self) -> int:
-        sorter = Sorter(self.poetry, self.io)
-        sorter.sort()
-        return 0
+        sorter = Sorter(self.poetry, self.io, check=self.option("check"))
+        return 0 if sorter.sort() else 1
 
 
 class SortDependenciesPlugin(ApplicationPlugin):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,20 +5,45 @@ import pytest
 from cleo.io.inputs.argv_input import ArgvInput
 
 
+@pytest.mark.parametrize(
+    ("argv", "input_fixture", "expected_output", "expected_rc"),
+    (
+        (
+            ["", "sort"],
+            "pyproject_multiple_groups.toml",
+            "pyproject_multiple_groups__sorted.toml",
+            0,
+        ),
+        (
+            ["", "sort", "--check"],
+            "pyproject_multiple_groups.toml",
+            "pyproject_multiple_groups.toml",
+            1,
+        ),
+        (
+            ["", "sort", "--check"],
+            "pyproject_multiple_groups__sorted.toml",
+            "pyproject_multiple_groups__sorted.toml",
+            0,
+        ),
+    ),
+)
 def test_sort_command(
     application_factory,
     fixture_dir,
     poetry_from_fixture,
+    argv,
+    input_fixture,
+    expected_output,
+    expected_rc,
 ):
-    poetry = poetry_from_fixture("pyproject_multiple_groups.toml")
+    poetry = poetry_from_fixture(input_fixture)
     app = application_factory(poetry)
 
-    app.run(input=ArgvInput(["", "sort"]))
+    assert app.run(input=ArgvInput(argv)) == expected_rc
 
     sorted_pyproject_content = poetry.file.path.read_text()
-    expected_pyproject_content = (
-        fixture_dir / "pyproject_multiple_groups__sorted.toml"
-    ).read_text()
+    expected_pyproject_content = (fixture_dir / expected_output).read_text()
     assert sorted_pyproject_content == expected_pyproject_content
 
 


### PR DESCRIPTION
An option to just check if dependencies are sorted, returning diagnostic messages and an error code that makes it easy to fail a CI correctness check.