### PR TITLE
feat: run on poetry check command

### DIFF
--- a/poetry_plugin_sort/plugins.py
+++ b/poetry_plugin_sort/plugins.py
@@ -10,6 +10,7 @@ from cleo.helpers import option
 from cleo.io.io import IO
 from poetry.console.application import Application
 from poetry.console.commands.add import AddCommand
+from poetry.console.commands.check import CheckCommand
 from poetry.console.commands.command import Command
 from poetry.console.commands.init import InitCommand
 from poetry.plugins.application_plugin import ApplicationPlugin
@@ -59,7 +60,7 @@ class SortDependenciesPlugin(ApplicationPlugin):
             )
             return
 
-        if not isinstance(command, (InitCommand, AddCommand)):
+        if not isinstance(command, (InitCommand, AddCommand, CheckCommand)):
             self._write_debug_lines(
                 io,
                 f"Skip sorting dependencies due to {command} does not change the"
@@ -79,7 +80,9 @@ class SortDependenciesPlugin(ApplicationPlugin):
             )
             return
 
-        sorter = Sorter(command.poetry, io)
+        check = isinstance(command, CheckCommand)
+
+        sorter = Sorter(command.poetry, io, check)
         sorter.sort()
 
     def _write_debug_lines(self, io: IO, message: str) -> None:

--- a/poetry_plugin_sort/plugins.py
+++ b/poetry_plugin_sort/plugins.py
@@ -83,7 +83,10 @@ class SortDependenciesPlugin(ApplicationPlugin):
         check = isinstance(command, CheckCommand)
 
         sorter = Sorter(command.poetry, io, check)
-        sorter.sort()
+        success = sorter.sort()
+
+        if check and not success:
+            exit(1)
 
     def _write_debug_lines(self, io: IO, message: str) -> None:
         if io.is_debug():

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -102,6 +102,49 @@ def test_sort_dependencies_after_calling_another_command(
 
 
 @pytest.mark.parametrize(
+    ("argv", "command_path", "input_fixture", "expected_output", "expected_rc"),
+    (
+        (
+            ["", "check"],
+            "poetry.console.commands.check.CheckCommand",
+            "pyproject_multiple_groups.toml",
+            "pyproject_multiple_groups.toml",
+            1,
+        ),
+        (
+            ["", "check"],
+            "poetry.console.commands.check.CheckCommand",
+            "pyproject_multiple_groups__sorted.toml",
+            "pyproject_multiple_groups__sorted.toml",
+            0,
+        ),
+    ),
+)
+def test_sort_on_check_command(
+    application_factory,
+    fixture_dir,
+    poetry_from_fixture,
+    argv: list[str],
+    command_path: str,
+    input_fixture: str,
+    expected_output: str,
+    expected_rc: int,
+):
+    """
+    Makes sure that dependencies sort check runs on `poetry check`
+    """
+    poetry = poetry_from_fixture(input_fixture)
+    app = application_factory(poetry)
+
+    rc = app.run(input=ArgvInput(argv))
+    sorted_pyproject_content = poetry.file.path.read_text()
+    expected_pyproject_content = (fixture_dir / expected_output).read_text()
+
+    assert sorted_pyproject_content == expected_pyproject_content
+    assert rc == expected_rc
+
+
+@pytest.mark.parametrize(
     ("argv", "command_path"),
     (
         (

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -101,47 +101,48 @@ def test_sort_dependencies_after_calling_another_command(
         assert sorted_pyproject_content == expected_pyproject_content
 
 
-@pytest.mark.parametrize(
-    ("argv", "command_path", "input_fixture", "expected_output", "expected_rc"),
-    (
-        (
-            ["", "check"],
-            "poetry.console.commands.check.CheckCommand",
-            "pyproject_multiple_groups.toml",
-            "pyproject_multiple_groups.toml",
-            1,
-        ),
-        (
-            ["", "check"],
-            "poetry.console.commands.check.CheckCommand",
-            "pyproject_multiple_groups__sorted.toml",
-            "pyproject_multiple_groups__sorted.toml",
-            0,
-        ),
-    ),
-)
 def test_sort_on_check_command(
     application_factory,
     fixture_dir,
     poetry_from_fixture,
-    argv: list[str],
-    command_path: str,
-    input_fixture: str,
-    expected_output: str,
-    expected_rc: int,
 ):
     """
     Makes sure that dependencies sort check runs on `poetry check`
     """
-    poetry = poetry_from_fixture(input_fixture)
+    poetry = poetry_from_fixture("pyproject_multiple_groups__sorted.toml")
     app = application_factory(poetry)
 
-    rc = app.run(input=ArgvInput(argv))
+    app.run(input=ArgvInput(["", "check"]))
+
     sorted_pyproject_content = poetry.file.path.read_text()
-    expected_pyproject_content = (fixture_dir / expected_output).read_text()
+    expected_pyproject_content = (
+        fixture_dir / "pyproject_multiple_groups__sorted.toml"
+    ).read_text()
 
     assert sorted_pyproject_content == expected_pyproject_content
-    assert rc == expected_rc
+
+
+def test_sort_on_check_command_failure(
+    application_factory,
+    fixture_dir,
+    poetry_from_fixture,
+):
+    """
+    Makes sure that dependencies sort check runs on `poetry check`
+    """
+    poetry = poetry_from_fixture("pyproject_multiple_groups.toml")
+    app = application_factory(poetry)
+
+    with pytest.raises(SystemExit) as excinfo:
+        app.run(input=ArgvInput(["", "check"]))
+
+    sorted_pyproject_content = poetry.file.path.read_text()
+    expected_pyproject_content = (
+        fixture_dir / "pyproject_multiple_groups.toml"
+    ).read_text()
+
+    assert sorted_pyproject_content == expected_pyproject_content
+    assert excinfo.value.code == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hooks `poetry sort --check` into `poetry check` command.

Fixes #9 